### PR TITLE
Update external link to WordPress Coding Standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WordPress Coding Standards Docs
 
-This repo contains the source for the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/installing-a-local-server/) on https://developer.wordpress.org
+This repo contains the source for the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) on https://developer.wordpress.org
 
 When creating new files, these must be added to the [manifest.json](https://github.com/WordPress-Coding-Standards/docs/blob/master/manifest.json) file. 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WordPress Coding Standards Docs
 
-This repo contains the source for the [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/) on https://developer.wordpress.org
+This repo contains the source for the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/installing-a-local-server/) on https://developer.wordpress.org
 
 When creating new files, these must be added to the [manifest.json](https://github.com/WordPress-Coding-Standards/docs/blob/master/manifest.json) file. 
 


### PR DESCRIPTION
Current external link goes to not found (404).